### PR TITLE
chore: use `yarn` in electron

### DIFF
--- a/docs/integrate/quick-start/electron.en.md
+++ b/docs/integrate/quick-start/electron.en.md
@@ -27,10 +27,10 @@ Run the following commands in sequence:
 $ git clone git@github.com:opensumi/ide-electron.git
 $ cd ide-electron
 $ yarn
-$ yarn run build
-$ yarn run rebuild-native -- --force-rebuild=true
-$ yarn run download-extension # install built-in extensions (optional)  
-$ yarn run start
+$ yarn build
+$ yarn rebuild-native -- --force-rebuild=true
+$ yarn download-extension # install built-in extensions (optional)  
+$ yarn start
 ```
 
 ## Development 
@@ -38,18 +38,18 @@ $ yarn run start
 Run in the project root directory
 
 ```bash
-$ yarn run watch
+$ yarn watch
 ```
 
 Start
 
 ```bash
-$ yarn run start
+$ yarn start
 ```
 
 ## Package
 
-Run `yarn run pack` to package the project. The installation package will be exported in the `out` directory.   
+Run `yarn pack` to package the project. The installation package will be exported in the `out` directory.   
 
 
 ## npm Image Configuration

--- a/docs/integrate/quick-start/electron.en.md
+++ b/docs/integrate/quick-start/electron.en.md
@@ -26,11 +26,11 @@ Run the following commands in sequence:
 ```bash
 $ git clone git@github.com:opensumi/ide-electron.git
 $ cd ide-electron
-$ npm install
-$ npm run build
-$ npm run rebuild-native -- --force-rebuild=true
-$ npm run download-extension # install built-in extensions (optional)  
-$ npm run start
+$ yarn
+$ yarn run build
+$ yarn run rebuild-native -- --force-rebuild=true
+$ yarn run download-extension # install built-in extensions (optional)  
+$ yarn run start
 ```
 
 ## Development 
@@ -38,18 +38,18 @@ $ npm run start
 Run in the project root directory
 
 ```bash
-$ npm run watch
+$ yarn run watch
 ```
 
 Start
 
 ```bash
-$ npm run start
+$ yarn run start
 ```
 
 ## Package
 
-Run `npm run pack` to package the project. The installation package will be exported in the `out` directory.   
+Run `yarn run pack` to package the project. The installation package will be exported in the `out` directory.   
 
 
 ## npm Image Configuration

--- a/docs/integrate/quick-start/electron.zh.md
+++ b/docs/integrate/quick-start/electron.zh.md
@@ -27,10 +27,10 @@ OpenSumi 内部集成了一个简易的 Electron 框架，旨在提供一个快�
 $ git clone git@github.com:opensumi/ide-electron.git
 $ cd ide-electron
 $ yarn
-$ yarn run build
-$ yarn run rebuild-native -- --force-rebuild=true
-$ yarn run download-extension # 安装内置插件（可选）
-$ yarn run start
+$ yarn build
+$ yarn rebuild-native -- --force-rebuild=true
+$ yarn download-extension # 安装内置插件（可选）
+$ yarn start
 ```
 
 ## 开发
@@ -38,18 +38,18 @@ $ yarn run start
 在项目根目录运行：
 
 ```bash
-$ yarn run watch
+$ yarn watch
 ```
 
 启动：
 
 ```bash
-$ yarn run start
+$ yarn start
 ```
 
 ## 打包
 
-运行 `yarn run pack` 即可将项目打包，打包后的安装包将输出在 `out` 目录。
+运行 `yarn pack` 即可将项目打包，打包后的安装包将输出在 `out` 目录。
 
 ## npm 镜像配置
 

--- a/docs/integrate/quick-start/electron.zh.md
+++ b/docs/integrate/quick-start/electron.zh.md
@@ -26,11 +26,11 @@ OpenSumi 内部集成了一个简易的 Electron 框架，旨在提供一个快�
 ```bash
 $ git clone git@github.com:opensumi/ide-electron.git
 $ cd ide-electron
-$ npm install
-$ npm run build
-$ npm run rebuild-native -- --force-rebuild=true
-$ npm run download-extension # 安装内置插件（可选）
-$ npm run start
+$ yarn
+$ yarn run build
+$ yarn run rebuild-native -- --force-rebuild=true
+$ yarn run download-extension # 安装内置插件（可选）
+$ yarn run start
 ```
 
 ## 开发
@@ -38,18 +38,18 @@ $ npm run start
 在项目根目录运行：
 
 ```bash
-$ npm run watch
+$ yarn run watch
 ```
 
 启动：
 
 ```bash
-$ npm run start
+$ yarn run start
 ```
 
 ## 打包
 
-运行 `npm run pack` 即可将项目打包，打包后的安装包将输出在 `out` 目录。
+运行 `yarn run pack` 即可将项目打包，打包后的安装包将输出在 `out` 目录。
 
 ## npm 镜像配置
 


### PR DESCRIPTION
According to https://github.com/opensumi/ide-electron, `npm` should be replaced with `yarn`