### PR TITLE
chore: remove deprecated static-resource

### DIFF
--- a/docs/develop/basic-design/core-modules.en.md
+++ b/docs/develop/basic-design/core-modules.en.md
@@ -93,7 +93,6 @@ One of the most important criteria to determine a module belongs to an `underlyi
 ├── scm                           # The abstract interface of Source Control functionality, offering a standard VS Code SCM API, such as Git extensions that are implemented based on the SCM interface  
 ├── search                        # Cross-file text search functionality
 ├── startup                       # OpenSumi Example module that can be used to start OpenSumi based on the Startup module in development state 
-├── static-resource               # Static resource service management module
 ├── status-bar                    # Status bar functionality implementation, offering standard VS Code StatusBar APIs
 ├── storage                       # Storage functionality implementation, mainly maintaining reading and writing of various cache in OpenSumi  
 ├── task                          # Task functionality implementation, offering standard VS Code Task APIs

--- a/docs/develop/basic-design/core-modules.zh.md
+++ b/docs/develop/basic-design/core-modules.zh.md
@@ -93,7 +93,6 @@ extension-manager 主要负责插件的安装、管理、启/禁用等功能，�
 ├── scm                           # Source Control 功能抽象接口，并提供了标准的 VS Code SCM API，例如 Git 插件就是基于 SCM 提供的接口实现的
 ├── search                        # 跨文件文本搜索功能实现
 ├── startup                       # 示例模块，开发状态下可以基于 startup 模块来启动 OpenSumi
-├── static-resource               # 静态资源服务管理模块
 ├── status-bar                    # 状态栏功能实现，并提供标准的 VS Code StatusBar API
 ├── storage                       # 存储功能实现，主要维护 OpenSumi 内的各种缓存读写
 ├── task                          # 任务功能实现，并提供标准的 VS Code Task API


### PR DESCRIPTION
去除已废弃的 `static-resource` 模块说明